### PR TITLE
Make valueOrNull Nullable instead of NonNull

### DIFF
--- a/jooby/src/main/java/io/jooby/Value.java
+++ b/jooby/src/main/java/io/jooby/Value.java
@@ -237,7 +237,7 @@ public interface Value extends Iterable<Value> {
    *
    * @return Convert this value to String (if possible) or <code>null</code> when missing.
    */
-  @Nonnull default String valueOrNull() {
+  @Nullable default String valueOrNull() {
     return value((String) null);
   }
 


### PR DESCRIPTION
The method Value.valueOrNull() is marked as NonNull, this fixes that and marks it as Nullable

Closes #1362